### PR TITLE
Improve audio handling and docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Eddie Dunn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ pip install diarized-transcriber
 - PyTorch with CUDA support
 - HuggingFace account for `pyannote.audio` access
 
+Before running the examples below you must export an authentication token for
+the diarization pipeline. This token is referenced in
+`diarized_transcriber/transcription/diarization.py` (see lines 43–55) and is
+required for downloading the pretrained `pyannote.audio` model.
+
+```bash
+export HF_TOKEN="<your-huggingface-token>"
+```
+
 ## Quick Start
 
 ```python

--- a/src/diarized_transcriber/transcription/audio.py
+++ b/src/diarized_transcriber/transcription/audio.py
@@ -46,12 +46,27 @@ def load_audio(
             logger.debug(
                 "Resampling audio from %dHz to %dHz",
                 file_sample_rate,
-                sample_rate
+                sample_rate,
             )
-            # TODO: Implement resampling logic
-            # We can use torchaudio.transforms.Resample here
-            pass
-            
+
+            import torch
+            import torchaudio
+
+            waveform = torch.from_numpy(audio_data).float()
+            if waveform.ndim == 1:
+                waveform = waveform.unsqueeze(0)
+
+            resampler = torchaudio.transforms.Resample(
+                orig_freq=file_sample_rate,
+                new_freq=sample_rate,
+            )
+            waveform = resampler(waveform)
+
+            if waveform.shape[0] == 1:
+                audio_data = waveform.squeeze(0).numpy()
+            else:
+                audio_data = waveform.transpose(0, 1).numpy()
+
         return audio_data, sample_rate
             
     except Exception as e:

--- a/tests/transcription/test_engine.py
+++ b/tests/transcription/test_engine.py
@@ -1,0 +1,96 @@
+import sys
+import types
+import importlib
+from pathlib import Path
+import tempfile
+
+
+def test_transcription_engine_flow():
+    # Stub dependencies
+    pydantic = types.ModuleType("pydantic")
+    class BaseModel:
+        def __init__(self, **data):
+            for k, v in data.items():
+                setattr(self, k, v)
+    def Field(default=None, *, default_factory=None, **_kwargs):
+        if default_factory is not None:
+            return default_factory()
+        return default
+    pydantic.BaseModel = BaseModel
+    pydantic.Field = Field
+    pydantic.HttpUrl = str
+    sys.modules["pydantic"] = pydantic
+
+    class DataFrame:
+        def __init__(self, rows):
+            self.data = [dict(row) for row in rows]
+        def iterrows(self):
+            for idx, row in enumerate(self.data):
+                yield idx, row
+    pandas = types.ModuleType("pandas")
+    pandas.DataFrame = DataFrame
+    sys.modules["pandas"] = pandas
+
+    whisperx = types.ModuleType("whisperx")
+    class DummyModel:
+        def transcribe(self, audio):
+            return {"segments": [{"start": 0.0, "end": 1.0, "text": "hi"}], "language": "en"}
+    def load_model(model_size, device=None, compute_type=None):
+        return DummyModel()
+    def load_align_model(language_code, device=None):
+        return "align_model", {}
+    def align(segments, align_model, metadata, audio_array, device, return_char_alignments=False):
+        return {"segments": segments, "language": "en"}
+    whisperx.load_model = load_model
+    whisperx.load_align_model = load_align_model
+    whisperx.align = align
+    sys.modules["whisperx"] = whisperx
+
+    pkg = types.ModuleType("diarized_transcriber")
+    pkg.__path__ = [str(Path(__file__).resolve().parents[2] / "src" / "diarized_transcriber")]
+    sys.modules["diarized_transcriber"] = pkg
+
+    engine_mod = importlib.import_module("diarized_transcriber.transcription.engine")
+    content_mod = importlib.import_module("diarized_transcriber.models.content")
+    transcription_mod = importlib.import_module("diarized_transcriber.models.transcription")
+
+    engine_mod.verify_gpu_requirements = lambda: "cpu"
+    engine_mod.cleanup_gpu_memory = lambda: None
+
+    audio_mod = importlib.import_module("diarized_transcriber.transcription.audio")
+    audio_mod.process_media_content = lambda content: ([0.0], 16000)
+    def create_temp_audio_file(data, sr):
+        tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        return tmp.name, tmp
+    audio_mod.create_temp_audio_file = create_temp_audio_file
+
+    Speaker = transcription_mod.Speaker
+    TimeSegment = transcription_mod.TimeSegment
+    class DummyDiarization:
+        def process_audio(self, path, min_speakers=None, max_speakers=None):
+            return [Speaker(id="A", segments=[TimeSegment(start=0.0, end=1.0)])]
+        def assign_speakers_to_segments(self, speakers, segments):
+            for row in segments.data:
+                row["speaker"] = speakers[0].id
+            return segments
+    engine_mod.DiarizationPipeline = lambda device=None: DummyDiarization()
+
+    MediaContent = content_mod.MediaContent
+    MediaSource = content_mod.MediaSource
+
+    engine = engine_mod.TranscriptionEngine(model_size="tiny", device="cpu")
+    content = MediaContent(
+        id="1",
+        title="Test",
+        media_url="http://example.com/audio.wav",
+        source=MediaSource(type="podcast"),
+    )
+
+    result = engine.transcribe(content)
+
+    assert result.content_id == "1"
+    assert len(result.segments) == 1
+    seg = result.segments[0]
+    assert seg.text == "hi"
+    assert seg.speaker == "A"
+


### PR DESCRIPTION
## Summary
- implement resampling using torchaudio in `load_audio`
- clarify HF_TOKEN requirement in README
- add an MIT license file
- add basic integration test for `TranscriptionEngine`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683ca3128290833097e58e78ff52fbc8