### PR TITLE
Add FastAPI server with API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,20 @@ transcript_dict = format_transcript(
 )
 ```
 
+## Running the FastAPI server
+
+Install the optional dependencies:
+
+```bash
+pip install diarized-transcriber[server]
+```
+
+Start the service:
+
+```bash
+python -m diarized_transcriber.api.server
+```
+
 ## Error Handling
 
 The library provides specific exceptions for different error cases:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,10 @@ dev = [
     "mypy",
     "ruff",
 ]
+server = [
+    "fastapi",
+    "uvicorn"
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/diarized_transcriber"]

--- a/src/diarized_transcriber/api/schemas.py
+++ b/src/diarized_transcriber/api/schemas.py
@@ -1,0 +1,35 @@
+"""Pydantic models for the API layer."""
+
+from typing import Optional, Literal
+from pydantic import BaseModel, Field, HttpUrl
+
+from ..models.transcription import TranscriptionResult
+
+
+class TranscriptionRequest(BaseModel):
+    """Request body for the transcription endpoint."""
+
+    id: str = Field(description="Unique identifier for the content")
+    title: str = Field(description="Title of the content")
+    media_url: HttpUrl = Field(description="URL to the media file")
+    model_size: Optional[
+        Literal["tiny", "base", "small", "medium", "large"]
+    ] = Field(
+        default=None,
+        description="WhisperX model size to use"
+    )
+    min_speakers: Optional[int] = Field(
+        default=None, description="Minimum number of speakers"
+    )
+    max_speakers: Optional[int] = Field(
+        default=None, description="Maximum number of speakers"
+    )
+
+
+class TranscriptionResponse(BaseModel):
+    """Response returned by the transcription endpoint."""
+
+    result: TranscriptionResult = Field(
+        description="Transcription result for the requested media"
+    )
+

--- a/src/diarized_transcriber/api/server.py
+++ b/src/diarized_transcriber/api/server.py
@@ -1,0 +1,56 @@
+"""HTTP server exposing transcription capabilities via FastAPI."""
+
+from fastapi import FastAPI, HTTPException
+
+from ..models.content import MediaContent, MediaSource
+from ..transcription.engine import TranscriptionEngine
+
+from .schemas import TranscriptionRequest, TranscriptionResponse
+
+
+app = FastAPI(title="Diarized Transcriber")
+
+
+@app.get("/")
+def read_root() -> dict[str, str]:
+    """Basic health endpoint."""
+
+    return {"status": "ok"}
+
+
+@app.post("/transcribe", response_model=TranscriptionResponse)
+def transcribe(req: TranscriptionRequest) -> TranscriptionResponse:
+    """Transcribe the provided media file."""
+
+    try:
+        engine = TranscriptionEngine(
+            model_size=req.model_size or "base"
+        )
+
+        content = MediaContent(
+            id=req.id,
+            title=req.title,
+            media_url=req.media_url,
+            source=MediaSource(type="local"),
+        )
+
+        result = engine.transcribe(
+            content,
+            min_speakers=req.min_speakers,
+            max_speakers=req.max_speakers,
+        )
+        return TranscriptionResponse(result=result)
+    except Exception as exc:  # pragma: no cover - fastapi handles
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import uvicorn
+
+    uvicorn.run(
+        "diarized_transcriber.api.server:app",
+        host="0.0.0.0",
+        port=8000,
+        reload=False,
+    )
+

--- a/tests/api/test_server.py
+++ b/tests/api/test_server.py
@@ -1,0 +1,317 @@
+import sys
+import types
+import importlib
+from pathlib import Path
+
+
+def test_transcribe_endpoint():
+    # Stub pydantic
+    pydantic = types.ModuleType("pydantic")
+    class BaseModel:
+        def __init__(self, **data):
+            for k, v in data.items():
+                setattr(self, k, v)
+    def Field(default=None, *, default_factory=None, **_kwargs):
+        if default_factory is not None:
+            return default_factory()
+        return default
+    pydantic.BaseModel = BaseModel
+    pydantic.Field = Field
+    pydantic.HttpUrl = str
+    sys.modules["pydantic"] = pydantic
+
+    # Stub heavy deps
+    torch = types.ModuleType("torch")
+    sys.modules["torch"] = torch
+    numpy = types.ModuleType("numpy")
+    numpy.ndarray = list
+    sys.modules["numpy"] = numpy
+
+    pandas = types.ModuleType("pandas")
+    class Series:
+        def __init__(self, data):
+            self.data = list(data)
+        def __le__(self, other):
+            return Series([x <= other for x in self.data])
+        def __ge__(self, other):
+            return Series([x >= other for x in self.data])
+        def __and__(self, other):
+            return Series([a and b for a, b in zip(self.data, other.data)])
+        @property
+        def iloc(self):
+            class ILoc:
+                def __init__(self, data):
+                    self._data = data
+                def __getitem__(self, idx):
+                    return self._data[idx]
+            return ILoc(self.data)
+        @property
+        def empty(self):
+            return len(self.data) == 0
+        def __iter__(self):
+            return iter(self.data)
+    class DataFrame:
+        def __init__(self, data):
+            self.data = [dict(row) for row in data]
+        def __getitem__(self, key):
+            if isinstance(key, str):
+                return Series([row.get(key) for row in self.data])
+            if isinstance(key, Series):
+                filtered = [row for row, flag in zip(self.data, key.data) if flag]
+                return DataFrame(filtered)
+            raise TypeError("Unsupported key type")
+        def __setitem__(self, key, value):
+            values = value.data if isinstance(value, Series) else value
+            for row, val in zip(self.data, values):
+                row[key] = val
+        def apply(self, func, axis=0):
+            assert axis == 1
+            return Series([func(row) for row in self.data])
+        @property
+        def empty(self):
+            return len(self.data) == 0
+    pandas.DataFrame = DataFrame
+    sys.modules["pandas"] = pandas
+
+    whisperx = types.ModuleType("whisperx")
+    sys.modules["whisperx"] = whisperx
+    soundfile = types.ModuleType("soundfile")
+    soundfile.write = lambda *a, **k: None
+    soundfile.read = lambda *a, **k: ([0.0], 16000)
+    sys.modules["soundfile"] = soundfile
+
+    pyannote = types.ModuleType("pyannote")
+    pyannote_audio = types.ModuleType("pyannote.audio")
+    pyannote_audio.Pipeline = type("Pipeline", (), {"from_pretrained": classmethod(lambda cls,*a,**k: cls()), "to": lambda self,d:self})
+    pyannote.audio = pyannote_audio
+    sys.modules["pyannote"] = pyannote
+    sys.modules["pyannote.audio"] = pyannote_audio
+
+    fastapi = types.ModuleType("fastapi")
+    class HTTPException(Exception):
+        def __init__(self, status_code=500, detail=None):
+            self.status_code = status_code
+            self.detail = detail
+    fastapi.HTTPException = HTTPException
+    class FastAPI:
+        def __init__(self, *a, **k):
+            self.routes = {}
+        def get(self, path):
+            def decorator(fn):
+                self.routes[("GET", path)] = fn
+                return fn
+            return decorator
+        def post(self, path, response_model=None):
+            def decorator(fn):
+                self.routes[("POST", path)] = fn
+                return fn
+            return decorator
+    fastapi.FastAPI = FastAPI
+    testclient = types.ModuleType("fastapi.testclient")
+    class Response:
+        def __init__(self, data):
+            self.data = data
+            self.status_code = 200
+        def json(self):
+            return self.data
+    class TestClient:
+        def __init__(self, app):
+            self.app = app
+        def post(self, path, json=None):
+            func = self.app.routes[("POST", path)]
+            schemas = importlib.import_module("diarized_transcriber.api.schemas")
+            req = schemas.TranscriptionRequest(**(json or {}))
+            result = func(req)
+            return Response(result.__dict__)
+    testclient.TestClient = TestClient
+    fastapi.testclient = testclient
+    sys.modules["fastapi"] = fastapi
+    sys.modules["fastapi.testclient"] = testclient
+
+    pkg = types.ModuleType("diarized_transcriber")
+    pkg.__path__ = [str(Path(__file__).resolve().parents[2] / "src" / "diarized_transcriber")]
+    sys.modules["diarized_transcriber"] = pkg
+
+    engine_mod = importlib.import_module("diarized_transcriber.transcription.engine")
+    transcription_mod = importlib.import_module("diarized_transcriber.models.transcription")
+
+    class DummyEngine:
+        def __init__(self, *args, model_size="base", **kwargs):
+            self.called_with = model_size
+        def transcribe(self, content, min_speakers=None, max_speakers=None):
+            return transcription_mod.TranscriptionResult(
+                content_id=content.id,
+                language="en",
+                segments=[],
+                speakers=None,
+                metadata={}
+            )
+
+    server = importlib.import_module("diarized_transcriber.api.server")
+    schemas = importlib.import_module("diarized_transcriber.api.schemas")
+    server.TranscriptionEngine = DummyEngine
+
+    client = testclient.TestClient(server.app)
+    resp = client.post(
+        "/transcribe",
+        json={"id": "1", "title": "Example", "media_url": "http://example.com/a.mp3"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["result"].content_id == "1"
+
+    # Clean up imported engine module for other tests
+    sys.modules.pop("diarized_transcriber.transcription.engine", None)
+
+
+def test_health_endpoint():
+    """Ensure the root endpoint returns a health status."""
+
+    # Reuse the heavy dependency stubs from the previous test
+    pydantic = types.ModuleType("pydantic")
+    class BaseModel:
+        def __init__(self, **data):
+            for k, v in data.items():
+                setattr(self, k, v)
+    def Field(default=None, *, default_factory=None, **_kwargs):
+        if default_factory is not None:
+            return default_factory()
+        return default
+    pydantic.BaseModel = BaseModel
+    pydantic.Field = Field
+    pydantic.HttpUrl = str
+    sys.modules["pydantic"] = pydantic
+
+    torch = types.ModuleType("torch")
+    sys.modules["torch"] = torch
+    numpy = types.ModuleType("numpy")
+    numpy.ndarray = list
+    sys.modules["numpy"] = numpy
+
+    pandas = types.ModuleType("pandas")
+    pandas.DataFrame = lambda *a, **k: None
+    sys.modules["pandas"] = pandas
+
+    whisperx = types.ModuleType("whisperx")
+    sys.modules["whisperx"] = whisperx
+    soundfile = types.ModuleType("soundfile")
+    soundfile.write = lambda *a, **k: None
+    soundfile.read = lambda *a, **k: ([0.0], 16000)
+    sys.modules["soundfile"] = soundfile
+
+    pyannote = types.ModuleType("pyannote")
+    pyannote_audio = types.ModuleType("pyannote.audio")
+    pyannote_audio.Pipeline = type("Pipeline", (), {"from_pretrained": classmethod(lambda cls, *a, **k: cls()), "to": lambda self, d: self})
+    pyannote.audio = pyannote_audio
+    sys.modules["pyannote"] = pyannote
+    sys.modules["pyannote.audio"] = pyannote_audio
+
+    fastapi = types.ModuleType("fastapi")
+    class HTTPException(Exception):
+        pass
+    fastapi.HTTPException = HTTPException
+    class FastAPI:
+        def __init__(self, *a, **k):
+            self.routes = {}
+        def get(self, path):
+            def decorator(fn):
+                self.routes[("GET", path)] = fn
+                return fn
+            return decorator
+        def post(self, path, response_model=None):
+            def decorator(fn):
+                self.routes[("POST", path)] = fn
+                return fn
+            return decorator
+    fastapi.FastAPI = FastAPI
+    sys.modules["fastapi"] = fastapi
+
+    pkg = types.ModuleType("diarized_transcriber")
+    pkg.__path__ = [str(Path(__file__).resolve().parents[2] / "src" / "diarized_transcriber")]
+    sys.modules["diarized_transcriber"] = pkg
+
+    server = importlib.import_module("diarized_transcriber.api.server")
+
+    assert server.read_root() == {"status": "ok"}
+
+    sys.modules.pop("diarized_transcriber.api.server", None)
+    sys.modules.pop("diarized_transcriber.transcription.engine", None)
+
+
+def test_server_main_runs_uvicorn():
+    """Verify that running the module as __main__ starts uvicorn."""
+
+    pydantic = types.ModuleType("pydantic")
+    pydantic.BaseModel = type("BaseModel", (), {})
+    pydantic.Field = lambda default=None, **_: default
+    pydantic.HttpUrl = str
+    sys.modules["pydantic"] = pydantic
+
+    torch = types.ModuleType("torch")
+    sys.modules["torch"] = torch
+    numpy = types.ModuleType("numpy")
+    numpy.ndarray = list
+    sys.modules["numpy"] = numpy
+
+    pandas = types.ModuleType("pandas")
+    pandas.DataFrame = lambda *a, **k: None
+    sys.modules["pandas"] = pandas
+
+    whisperx = types.ModuleType("whisperx")
+    sys.modules["whisperx"] = whisperx
+    soundfile = types.ModuleType("soundfile")
+    soundfile.write = lambda *a, **k: None
+    soundfile.read = lambda *a, **k: ([0.0], 16000)
+    sys.modules["soundfile"] = soundfile
+
+    pyannote = types.ModuleType("pyannote")
+    pyannote_audio = types.ModuleType("pyannote.audio")
+    pyannote_audio.Pipeline = type("Pipeline", (), {"from_pretrained": classmethod(lambda cls, *a, **k: cls()), "to": lambda self, d: self})
+    pyannote.audio = pyannote_audio
+    sys.modules["pyannote"] = pyannote
+    sys.modules["pyannote.audio"] = pyannote_audio
+
+    fastapi = types.ModuleType("fastapi")
+    class HTTPException(Exception):
+        pass
+    fastapi.HTTPException = HTTPException
+    class FastAPI:
+        def __init__(self, *a, **k):
+            self.routes = {}
+        def get(self, path):
+            def decorator(fn):
+                self.routes[("GET", path)] = fn
+                return fn
+            return decorator
+        def post(self, path, response_model=None):
+            def decorator(fn):
+                self.routes[("POST", path)] = fn
+                return fn
+            return decorator
+    fastapi.FastAPI = FastAPI
+    sys.modules["fastapi"] = fastapi
+
+    uvicorn = types.ModuleType("uvicorn")
+    def run(app_path, host="0.0.0.0", port=8000, reload=False):
+        run.called = {
+            "app_path": app_path,
+            "host": host,
+            "port": port,
+            "reload": reload,
+        }
+    uvicorn.run = run
+    sys.modules["uvicorn"] = uvicorn
+
+    pkg = types.ModuleType("diarized_transcriber")
+    pkg.__path__ = [str(Path(__file__).resolve().parents[2] / "src" / "diarized_transcriber")]
+    sys.modules["diarized_transcriber"] = pkg
+
+    import runpy
+    sys.modules.pop("diarized_transcriber.api.server", None)
+    runpy.run_module("diarized_transcriber.api.server", run_name="__main__")
+
+    assert run.called["app_path"] == "diarized_transcriber.api.server:app"
+    assert run.called["port"] == 8000
+
+    sys.modules.pop("diarized_transcriber.api.server", None)
+    sys.modules.pop("diarized_transcriber.transcription.engine", None)
+    sys.modules.pop("uvicorn", None)


### PR DESCRIPTION
## Summary
- add optional `server` extra with FastAPI deps
- define API request/response schemas
- implement FastAPI app exposing `/transcribe`
- document running the server
- include API endpoint tests
- extend API tests with health and entry point coverage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683cf58203308330a4a3d44ee5796562